### PR TITLE
Supported word character before/after [:space:], ^ or $, \W

### DIFF
--- a/plugin/textobj/underscore.vim
+++ b/plugin/textobj/underscore.vim
@@ -10,29 +10,54 @@ call textobj#user#plugin('underscore', {
 \      }
 \    })
 
+" Start Pos:
+" 1. "_" ("foo[_]bar[_]baz")
+" word character after
+" 2. [:space:] ("  [f]oo_bar_baz")
+" 3. ^ ("[f]oo_bar_baz")
+" 4. \W (":[s]mile:")
+"
+" End Pos:
+" 1. "_" ("foo[_]bar[_]baz")
+" word character before
+" 2. [:space:] ("foo_bar_ba[z]  ")
+" 3. $ ("foo_bar_ba[z]")
+" 4. \W (":smil[e]:")
 function! s:select_a()
-  normal! F_
+  let pattern = '\%' . line('.') . 'l\%(_\|\%([[:space:]]\|^\|\W\)\zs\w\)'
+  call search(pattern, 'bcW')
+  let start_pos = getpos('.')
 
+  let pattern = '\%' . line('.') . 'l\%(_\|\w\ze\%([[:space:]]\|$\|\W\)\)'
+  call search(pattern, 'W')
   let end_pos = getpos('.')
 
-  normal! f_
-
-  let start_pos = getpos('.')
-  return ['v', start_pos, end_pos]
+  return (start_pos ==# end_pos ? 0 : ['v', start_pos, end_pos])
 endfunction
 
-" ciao_come_stai
-
+" Start Pos:
+" word character after
+" 1. "_" ("foo_[b]ar_[b]az")
+" 2. [:space:] ("  [f]oo_bar_baz")
+" 3. ^ ("[f]oo_bar_baz")
+" 4. \W (":[s]mile:")
+"
+" End Pos:
+" word character before
+" 1. "_" ("fo[o]_ba[r]_baz")
+" 2. [:space:] ("foo_bar_ba[z]  ")
+" 3. $ ("foo_bar_ba[z]")
+" 4. \W (":smil[e]:")
 function! s:select_i()
-  normal! T_
-
-  let end_pos = getpos('.')
-
-  normal! t_
-
+  let pattern = '\%' . line('.') . 'l\%([_[:space:]]\|^\|\W\)\zs\w'
+  call search(pattern, 'bcW')
   let start_pos = getpos('.')
 
-  return ['v', start_pos, end_pos]
+  let pattern = '\%' . line('.') . 'l\w\ze\%([_[:space:]]\|$\|\W\)'
+  call search(pattern, 'cW')
+  let end_pos = getpos('.')
+
+  return (start_pos ==# end_pos ? 0 : ['v', start_pos, end_pos])
 endfunction
 
 let g:loaded_textobj_underscore = 1


### PR DESCRIPTION
Sorry, almost implementation were rewritten.
However, I thought I should send a pull request
because I hope this saves existing vim-textobj-underscore users too :)

Supported 3 extra cases.
- `a_` Keymapping
  1. `"  [foo_]bar_baz"`
  2. `"[foo_]bar_baz"`
  3. `":[smile]:"`
- `i_` Keymapping
  1. `"  [foo]_bar_baz"`
  2. `"[foo]_bar_baz"`
  3. `":[smile]:"`

and if no matching text-object is found, both `i_` and `a_` select nothing (functions return `0`).
# `a_` Keymapping
## Start Pos

Search for...

1. `_` (`"foo[_]bar[_]baz"`)
- This is a supported character currently.

Word character after

2. `[:space:]` (`"  [f]oo_bar_baz"`)
3. `^` (`"[f]oo_bar_baz"`)
4. `\W` (`":[s]mile:"`)
## End Pos

Search for...

1. `_` (`"foo[_]bar[_]baz"`)
- This is a supported character currently.

Word character before

2. `[:space:]` (`"foo_bar_ba[z]  "`)
3. `$` (`"foo_bar_ba[z]"`)
4. `\W` (`":smil[e]:"`)
# `i_` Keymapping
## Start Pos

Word character after
1. `_` (`"foo_[b]ar_[b]az"`)
   - This is a supported character currently.
2. `[:space:]` (`"  [f]oo_bar_baz"`)
3. `^` (`"[f]oo_bar_baz"`)
4. `\W` (`":[s]mile:"`)
## End Pos

Word character before
1. `_` (`"fo[o]_ba[r]_baz"`)
   - This is a supported character currently.
2. `[:space:]` (`"foo_bar_ba[z]  "`)
3. `$` (`"foo_bar_ba[z]"`)
4. `\W` (`":smil[e]:"`)
